### PR TITLE
Preprocessing now callable from the terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ elastix/Outputs_experiments_transformix
 elastix/parameters
 metrics
 trash.py
+*.bat
 
 
 # Byte-compiled / optimized / DLL files

--- a/preprocessing/preprocessing.py
+++ b/preprocessing/preprocessing.py
@@ -3,6 +3,10 @@ from pathlib import Path
 from skimage import exposure
 import matplotlib.pyplot as plt
 import numpy as np
+from tqdm import tqdm
+import click
+
+
 thispath = Path.cwd().resolve()
 
 
@@ -32,29 +36,32 @@ def CT_normalization(lung_images, patient_num, intro_images_description, clahe=T
     """
     inhale = lung_images[0]
     inhale_image = inhale.get_fdata().copy()
-    inhale_image = exposure.rescale_intensity(inhale_image, in_range='image', out_range=(0, 1))
-
+    inhale_image = exposure.rescale_intensity(inhale_image, in_range='image', out_range=(-2000, 2000))
     exhale = lung_images[1]
     exhale_image = exhale.get_fdata().copy()
-    exhale_image = exposure.rescale_intensity(exhale_image, in_range='image', out_range=(0, 1))
+    exhale_image = exposure.rescale_intensity(exhale_image, in_range='image', out_range=(-2000, 2000))
 
+    # Save the contrast enhanced images only if we are just running normalization
     header_in = nib.Nifti1Header()
-    inhale_im = nib.Nifti1Image(np.float32(inhale_image), inhale.affine, header_in)
-
-    Path(thispath/f'data/train_Normalized/{patient_num}').mkdir(exist_ok=True, parents=True)
-    nib.save(inhale_im,
-             Path(thispath/f'data/train_Normalized/{patient_num}/{patient_num}_iBHCT.nii.gz'))
+    inhale_im = nib.Nifti1Image(np.int16(inhale_image), inhale.affine, header_in)
     header_ex = nib.Nifti1Header()
-    exhale_im = nib.Nifti1Image(np.float32(exhale_image), exhale.affine, header_ex)
-    nib.save(exhale_im,
-             Path(thispath/f'data/train_Normalized/{patient_num}/{patient_num}_eBHCT.nii.gz'))
+    exhale_im = nib.Nifti1Image(np.int16(exhale_image), exhale.affine, header_ex)
+    if not clahe:
+        dataset_ = intro_images_description.split('_')[0]
+        savingpath = thispath / f"data/{dataset_}{intro_images_description.replace(f'{dataset_}', '')}_Normalized/{patient_num}"
+        Path(savingpath).mkdir(exist_ok=True, parents=True)
+        nib.save(inhale_im,
+                 Path(savingpath / f'{patient_num}_iBHCT.nii.gz'))
+        nib.save(exhale_im,
+                 Path(savingpath / f'{patient_num}_eBHCT.nii.gz'))
 
     normalized_lung_image = (inhale_im, exhale_im)
 
     if plothist:
-        hist_plotting(lung_images, normalized_lung_image, patient_num, image_titles=[intro_images_description, "Normalized"])
+        hist_plotting(lung_images, normalized_lung_image, patient_num,
+                      image_titles=[intro_images_description, f"Normalized {intro_images_description}"])
     if clahe:
-        CT_CLAHE(normalized_lung_image, patient_num, "Normalized", plothistCLAHE=plothist)
+        CT_CLAHE(normalized_lung_image, patient_num, f"{intro_images_description}_Normalized", plothistCLAHE=plothist)
 
     return normalized_lung_image
 
@@ -83,6 +90,9 @@ def CT_CLAHE(lung_images, patient_num, intro_images_description, plothistCLAHE=F
         CLAHE_lung_images: tuple
         List of Nifti1Image objects. In the first position inhale image, in the second position exhale image.
         """
+    dataset_ = intro_images_description.split('_')[0]
+    savingpath = thispath / f"data/{dataset_}{intro_images_description.replace(f'{dataset_}','')}_CLAHE/{patient_num}"
+    Path(savingpath).mkdir(exist_ok=True, parents=True)
 
     inhale = lung_images[0]
     inhale_image = inhale.get_fdata()
@@ -92,24 +102,31 @@ def CT_CLAHE(lung_images, patient_num, intro_images_description, plothistCLAHE=F
     kernelsize = np.array((inhale_image.shape[0] // 5,
                            inhale_image.shape[1] // 5,
                            inhale_image.shape[2] // 5))
+    # CLAHE needs range of 0 to 1
+    inhale_image_01 = exposure.rescale_intensity(inhale_image, in_range='image', out_range=(0, 1))
+    inhale_CLAHE = exposure.equalize_adapthist(inhale_image_01, kernel_size=kernelsize)
+    # Converting back to original range of input images
+    inhale_CLAHE = exposure.rescale_intensity(inhale_CLAHE, in_range='image',
+                                              out_range=(np.amin(inhale_image), np.amax(inhale_image)))
 
-    inhale_CLAHE = exposure.equalize_adapthist(inhale_image, kernel_size=kernelsize)
-    exhale_CLAHE = exposure.equalize_adapthist(exhale_image, kernel_size=kernelsize)
-    # Save the contrast enhanced images
-    Path(thispath / f'data/train_{intro_images_description}CLAHE/{patient_num}').mkdir(exist_ok=True, parents=True)
+    exhale_image_01 = exposure.rescale_intensity(exhale_image, in_range='image', out_range=(0, 1))
+    exhale_CLAHE = exposure.equalize_adapthist(exhale_image_01, kernel_size=kernelsize)
+    exhale_CLAHE = exposure.rescale_intensity(exhale_CLAHE, in_range='image',
+                                              out_range=(np.amin(exhale_image), np.amax(exhale_image)))
+
     header_in = nib.Nifti1Header()
     inhale_im = nib.Nifti1Image(np.float32(inhale_CLAHE), inhale.affine, header_in)
     nib.save(inhale_im,
-             Path(thispath / f'data/train_{intro_images_description}CLAHE/{patient_num}/{patient_num}_iBHCT.nii.gz'))
+             Path(savingpath/f'{patient_num}_iBHCT.nii.gz'))
     header_ex = nib.Nifti1Header()
     exhale_im = nib.Nifti1Image(np.float32(exhale_CLAHE), exhale.affine, header_ex)
     nib.save(exhale_im,
-             Path(thispath / f'data/train_{intro_images_description}CLAHE/{patient_num}/{patient_num}_eBHCT.nii.gz'))
+             Path(savingpath/f'{patient_num}_eBHCT.nii.gz'))
 
     CLAHE_lung_images = (inhale_im, exhale_im)
 
     if plothistCLAHE:
-        hist_plotting(lung_images, CLAHE_lung_images, patient_num, image_titles=[intro_images_description, "CLAHE"])
+        hist_plotting(lung_images, CLAHE_lung_images, patient_num, image_titles=[intro_images_description, f"CLAHE of {intro_images_description}"])
 
     return CLAHE_lung_images
 
@@ -158,3 +175,38 @@ def hist_plotting(lung_images, processed_lung_images, patient_num, image_titles)
     axs[1, 1].title.set_text(f'{image_titles[1]} Exhale Histogram')
     plt.show()
 
+
+@click.command()
+@click.option(
+    "--train_type",
+    default="train",
+    prompt="Files path:",
+    help="Name of the train/test folder containing the images to preprocess",
+)
+@click.option(
+    "--preprocessing_type",
+    default="Normalized",
+    prompt="Preprocessing Technique:",
+    help="Name of the preprocessing to be done;Normalized,CLAHE or Normalized_CLAHE",
+)
+def main(train_type,preprocessing_type):
+
+    datadir = thispath / Path(f"data/{train_type}")
+    patients = [x.stem for x in datadir.iterdir() if x.is_dir()]
+    images_files_inhale = [i for i in datadir.rglob("*.nii.gz") if "copd" in str(i) and 'iBHCT' in str(i)]
+    images_files_exhale = [i for i in datadir.rglob("*.nii.gz") if "copd" in str(i) and 'eBHCT' in str(i)]
+    results_dir = Path(f"data/{train_type}_{preprocessing_type}")
+    results_dir.mkdir(parents=True, exist_ok=True)
+    # Read the chest CT scan
+    for i in tqdm(range(len(images_files_inhale))):
+        ct_image_inhale = nib.load(images_files_inhale[i])
+        ct_image_exhale = nib.load(images_files_exhale[i])
+        if preprocessing_type == 'Normalized':
+            CT_normalization((ct_image_inhale, ct_image_exhale), patients[i], f"{train_type}", clahe=False, plothist=False)
+        if preprocessing_type == 'CLAHE':
+            CT_CLAHE((ct_image_inhale, ct_image_exhale), patients[i], f"{train_type}", plothistCLAHE=False)
+        if preprocessing_type == 'Normalized_CLAHE':
+            CT_normalization((ct_image_inhale, ct_image_exhale), patients[i], f"{train_type}", clahe=True, plothist=False)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Change in the preprocessing.py to be callable in the terminal
- Files path: Should be the name of the train/test folder. ex. **train_gantry_removed**
- Preprocessing Technique (options): **Normalized, CLAHE or Normalized_CLAHE**
- Change in Normalization function to adjust range from -2000 to 2000 

